### PR TITLE
Improve fw update robustness to boot part corruption

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -3,15 +3,17 @@
 # Default paths if not specified via the commandline
 define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 
-# This configuration file will create an image that
-# has an MBR and the following 3 partitions:
+# This configuration file will create an image that has an MBR and the
+# following 3 partitions:
 #
 # +----------------------------+
 # | MBR                        |
 # +----------------------------+
-# | p0: Boot partition (FAT32) |
+# | p0*: Boot A (FAT32)        |
 # | zImage, bootcode.bin,      |
 # | config.txt, etc.           |
+# +----------------------------+
+# | p0*: Boot B (FAT32)        |
 # +----------------------------+
 # | p1*: Rootfs A (squashfs)   |
 # +----------------------------+
@@ -20,31 +22,31 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # | p2: Application (FAT32)    |
 # +----------------------------+
 #
-# The p1 partition points to whichever of Rootfs A or B that
-# is active.
+# The p0/p1 partition points to whichever of configurations A or B that is
+# active.
 #
-# The image is sized to be less than 1 GB so that it fits on
-# nearly any SDCard around. If you have a larger SDCard and
-# need more space, feel free to bump the partition sizes
-# below.
+# The image is sized to be less than 1 GB so that it fits on nearly any SDCard
+# around. If you have a larger SDCard and need more space, feel free to bump
+# the partition sizes below.
 
-# The Raspberry Pi is incredibly picky on the partition sizes
-# and in ways that I don't understand. Test changes one at a
-# time to make sure that they boot. (Sizes are in 512 byte
-# blocks)
-define(BOOT_PART_OFFSET, 63)
-define(BOOT_PART_COUNT, 77261)
+# The Raspberry Pi is incredibly picky on the partition sizes and in ways that
+# I don't understand. Test changes one at a time to make sure that they boot.
+# (Sizes are in 512 byte blocks)
+define(BOOT_A_PART_OFFSET, 63)
+define(BOOT_A_PART_COUNT, 38630)
+define-eval(BOOT_B_PART_OFFSET, "${BOOT_A_PART_OFFSET} + ${BOOT_A_PART_COUNT}")
+define(BOOT_B_PART_COUNT, ${BOOT_A_PART_COUNT})
 
-# Let the rootfs have room to grow up to 128 MiB and align
-# it to the nearest 1 MB boundary
+# Let the rootfs have room to grow up to 128 MiB and align it to the nearest 1
+# MB boundary
 define(ROOTFS_A_PART_OFFSET, 77324)
 define(ROOTFS_A_PART_COUNT, 289044)
-define(ROOTFS_B_PART_OFFSET, 366368)
-define(ROOTFS_B_PART_COUNT, 289044)
+define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
+define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
 
-# Application partition. This partition can occupy all of the
-# remaining space. Size it to fit the destination.
-define(APP_PART_OFFSET, 655412)
+# Application partition. This partition can occupy all of the remaining space.
+# Size it to fit the destination.
+define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
 define(APP_PART_COUNT, 1048576)
 
 # Firmware metadata
@@ -89,8 +91,8 @@ file-resource rootfs.img {
 
 mbr mbr-a {
     partition 0 {
-        block-offset = ${BOOT_PART_OFFSET}
-        block-count = ${BOOT_PART_COUNT}
+        block-offset = ${BOOT_A_PART_OFFSET}
+        block-count = ${BOOT_A_PART_COUNT}
         type = 0xc # FAT32
         boot = true
     }
@@ -109,8 +111,8 @@ mbr mbr-a {
 
 mbr mbr-b {
     partition 0 {
-        block-offset = ${BOOT_PART_OFFSET}
-        block-count = ${BOOT_PART_COUNT}
+        block-offset = ${BOOT_B_PART_OFFSET}
+        block-count = ${BOOT_B_PART_COUNT}
         type = 0xc # FAT32
         boot = true
     }
@@ -140,19 +142,19 @@ task complete {
     on-init {
         mbr_write(mbr-a)
 
-        fat_mkfs(${BOOT_PART_OFFSET}, ${BOOT_PART_COUNT})
-        fat_setlabel(${BOOT_PART_OFFSET}, "BOOT")
-        fat_mkdir(${BOOT_PART_OFFSET}, "overlays")
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
     }
 
-    on-resource config.txt { fat_write(${BOOT_PART_OFFSET}, "config.txt") }
-    on-resource cmdline.txt { fat_write(${BOOT_PART_OFFSET}, "cmdline.txt") }
-    on-resource bootcode.bin { fat_write(${BOOT_PART_OFFSET}, "bootcode.bin") }
-    on-resource start.elf { fat_write(${BOOT_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_PART_OFFSET}, "fixup.dat") }
-    on-resource zImage { fat_write(${BOOT_PART_OFFSET}, "zImage") }
-    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
-    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
+    on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
+    on-resource bootcode.bin { fat_write(${BOOT_A_PART_OFFSET}, "bootcode.bin") }
+    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
+    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
+    on-resource zImage { fat_write(${BOOT_A_PART_OFFSET}, "zImage") }
+    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
+    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
 
     on-resource rootfs.img {
         # write to the first rootfs partition
@@ -160,10 +162,16 @@ task complete {
     }
 
     on-finish {
-        # Initialize a big partition for application data
-        # This is done last so that the boot partition can be written to completely
-        # before the first write to this partition. Not skipping back and forth between
-        # FAT filesystems saves a little time when programming the Flash.
+        # Clear out any old data in the B partition that might be mistaken for
+        # a file system. This is mostly to avoid confusion in humans when
+        # reprogramming SDCards with unknown contents.
+        raw_memset(${BOOT_B_PART_OFFSET}, 8, 0xff)
+        raw_memset(${ROOTFS_B_PART_OFFSET}, 8, 0xff)
+
+        # Initialize a big partition for application data. This is done last so
+        # that the boot partition can be written to completely before the first
+        # write to this partition. Not skipping back and forth between FAT
+        # filesystems saves a little time when programming the Flash.
         fat_mkfs(${APP_PART_OFFSET}, ${APP_PART_COUNT})
         fat_setlabel(${APP_PART_OFFSET}, "APPDATA")
     }
@@ -173,75 +181,33 @@ task upgrade.a {
     # This task upgrades the A partition
     require-partition1-offset = ${ROOTFS_B_PART_OFFSET}
 
-    # Since the upgrade won't run until it has been finalized, it's ok
-    # to write data as it is read.
-    verify-on-the-fly = true
-
     on-init {
-        # Erase any old saved files from previous upgrades
-        fat_rm(${BOOT_PART_OFFSET}, "zImage.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "config.txt.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "cmdline.txt.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "bootcode.bin.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "start.elf.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "fixup.dat.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.pre")
-
-        # Make the overlays directory in case it isn't already there.
-        fat_mkdir(${BOOT_PART_OFFSET}, "overlays")
-        fat_rm(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.pre")
+        info("Upgrading the A partition")
+        # Reset the previous contents of the A boot partition
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
     }
 
-    # Write the new firmware and Linux images, but don't
-    # commit them. That way if the user aborts midway, we
-    # still are using the original firmware.
-    on-resource config.txt { fat_write(${BOOT_PART_OFFSET}, "config.txt.new") }
-    on-resource cmdline.txt { fat_write(${BOOT_PART_OFFSET}, "cmdline.txt.new") }
-    on-resource bootcode.bin { fat_write(${BOOT_PART_OFFSET}, "bootcode.bin.new") }
-    on-resource start.elf { fat_write(${BOOT_PART_OFFSET}, "start.elf.new") }
-    on-resource fixup.dat { fat_write(${BOOT_PART_OFFSET}, "fixup.dat.new") }
-    on-resource zImage { fat_write(${BOOT_PART_OFFSET}, "zImage.new") }
-    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new") }
-    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new") }
-
-    on-resource rootfs.img {
-        # write to the first rootfs partition
-        raw_write(${ROOTFS_A_PART_OFFSET})
-    }
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the B partition, so an error or power failure during this part
+    # won't hurt anything.
+    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
+    on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
+    on-resource bootcode.bin { fat_write(${BOOT_A_PART_OFFSET}, "bootcode.bin") }
+    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
+    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
+    on-resource zImage { fat_write(${BOOT_A_PART_OFFSET}, "zImage") }
+    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new") }
+    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new") }
+    on-resource rootfs.img { raw_write(${ROOTFS_A_PART_OFFSET}) }
 
     on-finish {
 	# Switch over to boot the new firmware
         mbr_write(mbr-a)
-
-        fat_mv(${BOOT_PART_OFFSET}, "zImage", "zImage.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "config.txt", "config.txt.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "cmdline.txt", "cmdline.txt.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "bootcode.bin", "bootcode.bin.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "start.elf", "start.elf.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "fixup.dat", "fixup.dat.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb", "bcm2710-rpi-3-b.dtb.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo", "overlays/w1-gpio-pullup.dtbo.pre")
-
-        fat_mv(${BOOT_PART_OFFSET}, "zImage.new", "zImage")
-        fat_mv(${BOOT_PART_OFFSET}, "config.txt.new", "config.txt")
-        fat_mv(${BOOT_PART_OFFSET}, "cmdline.txt.new", "cmdline.txt")
-        fat_mv(${BOOT_PART_OFFSET}, "bootcode.bin.new", "bootcode.bin")
-        fat_mv(${BOOT_PART_OFFSET}, "start.elf.new", "start.elf")
-        fat_mv(${BOOT_PART_OFFSET}, "fixup.dat.new", "fixup.dat")
-        fat_mv(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new", "bcm2710-rpi-3-b.dtb")
-        fat_mv(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new", "overlays/w1-gpio-pullup.dtbo")
     }
 
     on-error {
-        # Clean up in case something goes wrong
-        fat_rm(${BOOT_PART_OFFSET}, "zImage.new")
-        fat_rm(${BOOT_PART_OFFSET}, "config.txt.new")
-        fat_rm(${BOOT_PART_OFFSET}, "cmdline.txt.new")
-        fat_rm(${BOOT_PART_OFFSET}, "bootcode.bin.new")
-        fat_rm(${BOOT_PART_OFFSET}, "start.elf.new")
-        fat_rm(${BOOT_PART_OFFSET}, "fixup.dat.new")
-        fat_rm(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new")
-        fat_rm(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new")
     }
 }
 
@@ -249,69 +215,38 @@ task upgrade.b {
     # This task upgrades the B partition
     require-partition1-offset = ${ROOTFS_A_PART_OFFSET}
 
-    # Since the upgrade won't run until it has been finalized, it's ok
-    # to write data as it is read.
-    verify-on-the-fly = true
-
     on-init {
-        fat_rm(${BOOT_PART_OFFSET}, "zImage.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "config.txt.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "cmdline.txt.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "bootcode.bin.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "start.elf.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "fixup.dat.pre")
-        fat_rm(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.pre")
-
-        fat_mkdir(${BOOT_PART_OFFSET}, "overlays")
-        fat_rm(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.pre")
+        info("Upgrading the B partition")
+        # Reset the previous contents of the B boot partition
+        fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-B")
+        fat_mkdir(${BOOT_B_PART_OFFSET}, "overlays")
     }
 
-    on-resource config.txt { fat_write(${BOOT_PART_OFFSET}, "config.txt.new") }
-    on-resource cmdline.txt { fat_write(${BOOT_PART_OFFSET}, "cmdline.txt.new") }
-    on-resource bootcode.bin { fat_write(${BOOT_PART_OFFSET}, "bootcode.bin.new") }
-    on-resource start.elf { fat_write(${BOOT_PART_OFFSET}, "start.elf.new") }
-    on-resource fixup.dat { fat_write(${BOOT_PART_OFFSET}, "fixup.dat.new") }
-    on-resource zImage { fat_write(${BOOT_PART_OFFSET}, "zImage.new") }
-    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new") }
-    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new") }
-
-    on-resource rootfs.img {
-        # write to the first rootfs partition
-        raw_write(${ROOTFS_B_PART_OFFSET})
-    }
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the A partition, so an error or power failure during this part
+    # won't hurt anything.
+    on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
+    on-resource cmdline.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
+    on-resource bootcode.bin { fat_write(${BOOT_B_PART_OFFSET}, "bootcode.bin") }
+    on-resource start.elf { fat_write(${BOOT_B_PART_OFFSET}, "start.elf") }
+    on-resource fixup.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat") }
+    on-resource zImage { fat_write(${BOOT_B_PART_OFFSET}, "zImage") }
+    on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new") }
+    on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new") }
+    on-resource rootfs.img { raw_write(${ROOTFS_B_PART_OFFSET}) }
 
     on-finish {
 	# Switch over to boot the new firmware
         mbr_write(mbr-b)
-
-        fat_mv(${BOOT_PART_OFFSET}, "zImage", "zImage.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "config.txt", "config.txt.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "cmdline.txt", "cmdline.txt.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "bootcode.bin", "bootcode.bin.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "start.elf", "start.elf.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "fixup.dat", "fixup.dat.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb", "bcm2710-rpi-3-b.dtb.pre")
-        fat_mv(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo", "overlays/w1-gpio-pullup.dtbo.pre")
-
-        fat_mv(${BOOT_PART_OFFSET}, "zImage.new", "zImage")
-        fat_mv(${BOOT_PART_OFFSET}, "config.txt.new", "config.txt")
-        fat_mv(${BOOT_PART_OFFSET}, "cmdline.txt.new", "cmdline.txt")
-        fat_mv(${BOOT_PART_OFFSET}, "bootcode.bin.new", "bootcode.bin")
-        fat_mv(${BOOT_PART_OFFSET}, "start.elf.new", "start.elf")
-        fat_mv(${BOOT_PART_OFFSET}, "fixup.dat.new", "fixup.dat")
-        fat_mv(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new", "bcm2710-rpi-3-b.dtb")
-        fat_mv(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new", "overlays/w1-gpio-pullup.dtbo")
     }
 
     on-error {
-        # Clean up in case something goes wrong
-        fat_rm(${BOOT_PART_OFFSET}, "zImage.new")
-        fat_rm(${BOOT_PART_OFFSET}, "config.txt.new")
-        fat_rm(${BOOT_PART_OFFSET}, "cmdline.txt.new")
-        fat_rm(${BOOT_PART_OFFSET}, "bootcode.bin.new")
-        fat_rm(${BOOT_PART_OFFSET}, "start.elf.new")
-        fat_rm(${BOOT_PART_OFFSET}, "fixup.dat.new")
-        fat_rm(${BOOT_PART_OFFSET}, "bcm2710-rpi-3-b.dtb.new")
-        fat_rm(${BOOT_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo.new")
+    }
+    }
+
+task upgrade.unexpected {
+    on-init {
+        error("Please check the media being upgraded. It doesn't look like either the A or B partitions are active.")
     }
 }


### PR DESCRIPTION
This splits the boot partition into two like what is currently done with
the root filesystem. Previously, renaming files on the the FAT partition
was done to make things more atomic. This got out of hand with all of
the dtb files and it wasn't too hard to conceive of ways that the FAT
filesystem could become corrupt and affect future updates. Now a clean
FAT filesystem is formatted for the boot partition, the new files added
to it, and then at the very end, the MBR update to simultaneously swap
the boot partition and the rootfs.

The downside of this approach is that if any files are stored on the
boot partition by the application, they will be lost. This sometimes is
done as a one-time manufacturing provisioning step, but is not present
in any open-source use. Anyone using this approach will need to make a
custom fwup.conf to keep the old behavior.

Interestingly enough, it's possible to update an old installation with
this new fwup configuration since the rootfs partition didn't move
locations and that's the only thing checked when figuring out A vs. B.