### PR TITLE
Automount the boot partition as readonly

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -43,6 +43,7 @@
 #       nerves_runtime will auto-format it. Your applications will need to handle
 #       initializing any expected files and folders.
 -m /dev/mmcblk0p3:/root:ext4::
+-m /dev/mmcblk0p1:/boot:vfat::ro
 
 # Erlang release search path
 -r /srv/erlang


### PR DESCRIPTION
This is convenient to have around for debugging. We don't want to risk
corrupting it, so mount it as readonly.

Fixes #29 