### PR TITLE
Turn off console blanking on HDMI

### DIFF
--- a/cmdline.txt
+++ b/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty1 console=ttyS0,115200 root=/dev/mmcblk0p2 rootwait
+console=tty1 console=ttyS0,115200 root=/dev/mmcblk0p2 rootwait consoleblank=0


### PR DESCRIPTION
This makes it less frustrating to capture error messages on
keyboard-less systems.