### PR TITLE
Increase scrollback buffer size from 32k to 1024k.

### DIFF
--- a/cmdline.txt
+++ b/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty1 console=ttyS0,115200 root=/dev/mmcblk0p2 rootwait consoleblank=0
+console=tty1 console=ttyS0,115200 fbcon=scrollback:1024k root=/dev/mmcblk0p2 rootwait consoleblank=0


### PR DESCRIPTION
This will increase the framebuffer console's scrollback buffer size from the default 32k to 1024k.  Doing so should provide about 128 half pages of scrollback.  

#### References 

[Framebuffer Console docs](https://www.kernel.org/doc/Documentation/fb/fbcon.txt)
[TTY Scrollback Buffer Size](http://wiki.bitbinary.com/index.php/TTY_Scrollback_Buffer_Size)
[Arch - General troubleshooting - Scrollback](https://wiki.archlinux.org/index.php/General_troubleshooting#Scrollback)
