### PR TITLE
Assign "/dev/ttyAMA0" to GPIO pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.0-dev
+
+The serial port on the GPIO pins is now assigned to "dev/ttyAMA0" like all
+other RPi systems.
+
 ## v1.0.0-rc.2
 
 Upgraded the Linux kernel from 4.4 -> 4.9. Due to the coupling

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the base Nerves System configuration for the Raspberry Pi 3 Model B.
 | GPIO, I2C, SPI       | Yes - Elixir ALE                |
 | ADC                  | No                              |
 | PWM                  | Yes, but no Elixir support      |
-| UART                 | 1 available - ttyS0             |
+| UART                 | 1 available - ttyAMA0           |
 | Camera               | Yes - via rpi-userland          |
 | Ethernet             | Yes                             |
 | WiFi                 | Yes - Nerves.Network            |

--- a/config.txt
+++ b/config.txt
@@ -22,5 +22,6 @@ dtparam=i2c_arm=on,spi=on
 #       this won't work.
 #dtoverlay=w1-gpio-pullup,gpiopin=4
 
-# Enable the UART (/dev/ttyS0) on the RPi3.
+# Enable the UART (/dev/ttyAMA0) on the RPi3.
 enable_uart=1
+dtoverlay=pi3-miniuart-bt

--- a/fwup.conf
+++ b/fwup.conf
@@ -119,6 +119,9 @@ file-resource bcm2710-rpi-cm3.dtb {
 file-resource w1-gpio-pullup.dtbo {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup.dtbo"
 }
+file-resource pi3-miniuart-bt.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/pi3-miniuart-bt.dtbo"
+}
 
 file-resource rootfs.img {
     host-path = ${ROOTFS}
@@ -212,6 +215,7 @@ task complete {
     on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
     on-resource bcm2710-rpi-cm3.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-cm3.dtb") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource pi3-miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/pi3-miniuart-bt.dtbo") }
 
     on-resource rootfs.img {
         # write to the first rootfs partition
@@ -272,6 +276,7 @@ task upgrade.a {
     on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
     on-resource bcm2710-rpi-cm3.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2710-rpi-cm3.dtb") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource pi3-miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/pi3-miniuart-bt.dtbo") }
     on-resource rootfs.img { raw_write(${ROOTFS_A_PART_OFFSET}) }
 
     on-finish {
@@ -334,6 +339,7 @@ task upgrade.b {
     on-resource bcm2710-rpi-3-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-3-b.dtb") }
     on-resource bcm2710-rpi-cm3.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2710-rpi-cm3.dtb") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource pi3-miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/pi3-miniuart-bt.dtbo") }
     on-resource rootfs.img { raw_write(${ROOTFS_B_PART_OFFSET}) }
 
     on-finish {

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -5,7 +5,7 @@
 
 # Specify where erlinit should send the IEx prompt. Only one may be enabled at
 # a time.
-# -c ttyS0     # UART pins on the GPIO connector
+# -c ttyAMA0     # UART pins on the GPIO connector
 -c tty1      # HDMI output
 
 # If more than one tty are available, always warn if the user is looking at the


### PR DESCRIPTION
The device tree overlay "pi3-miniuart-bt" swaps the assignment of the two UARTs.
With this change the primary UART ("dev/ttyAMA0") is assigned to the GPIO pins, the mini UART ("dev/ttyS0") is assigned to the onboard bluetooth chip.
For more information on the RPi UARTs see https://www.raspberrypi.org/documentation/configuration/uart.md

I tested this on my RPi 3 B using this dependency configuration:
```
  defp system("rpi3"), do: [
      {:nerves_system_rpi3,
       github: "stefan991/nerves_system_rpi3", branch: "pi3-miniuart-bt", runtime: false}
    ]
```

Fixes #43