### PR TITLE
Move fwup uboot environment settings to an include file.

### DIFF
--- a/fwup-include/uboot.conf
+++ b/fwup-include/uboot.conf
@@ -1,0 +1,11 @@
+# Define the U-Boot env
+define(UBOOT_ENV_OFFSET, 16)
+define(UBOOT_ENV_COUNT, 16)  # 8 KB
+
+# Location where installed firmware information is stored.
+# While this is called "u-boot", u-boot isn't involved in this
+# setup. It just provides a convenient key/value store format.
+uboot-environment uboot-env {
+    block-offset = ${UBOOT_ENV_OFFSET}
+    block-count = ${UBOOT_ENV_COUNT}
+}

--- a/fwup.conf
+++ b/fwup.conf
@@ -2,6 +2,8 @@
 
 require-fwup-version="0.15.0"  # For the trim() call
 
+include("${NERVES_SYSTEM}/images/fwup-include/uboot.conf")
+
 #
 # Firmware metadata
 #
@@ -59,8 +61,6 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # The Raspberry Pi is incredibly picky on the partition sizes and in ways that
 # I don't understand. Test changes one at a time to make sure that they boot.
 # (Sizes are in 512 byte blocks)
-define(UBOOT_ENV_OFFSET, 16)
-define(UBOOT_ENV_COUNT, 16)  # 8 KB
 
 define(BOOT_A_PART_OFFSET, 63)
 define(BOOT_A_PART_COUNT, 38630)
@@ -171,14 +171,6 @@ mbr mbr-b {
         type = 0x83 # Linux
     }
     # partition 3 is unused
-}
-
-# Location where installed firmware information is stored.
-# While this is called "u-boot", u-boot isn't involved in this
-# setup. It just provides a convenient key/value store format.
-uboot-environment uboot-env {
-    block-offset = ${UBOOT_ENV_OFFSET}
-    block-count = ${UBOOT_ENV_COUNT}
 }
 
 # This firmware task writes everything to the destination media

--- a/mix.exs
+++ b/mix.exs
@@ -77,6 +77,7 @@ defmodule NervesSystemRpi3.MixProject do
       "nerves_defconfig",
       "README.md",
       "VERSION",
+      "fwup-include",
       "rootfs_overlay",
       "fwup.conf",
       "fwup-revert.conf",

--- a/post-build.sh
+++ b/post-build.sh
@@ -6,3 +6,6 @@ set -e
 # active firmware.
 mkdir -p $TARGET_DIR/usr/share/fwup
 $HOST_DIR/usr/bin/fwup -c -f $NERVES_DEFCONFIG_DIR/fwup-revert.conf -o $TARGET_DIR/usr/share/fwup/revert.fw
+
+# Copy the fwup includes to the images dir
+cp -rf $NERVES_DEFCONFIG_DIR/fwup-include $BINARIES_DIR


### PR DESCRIPTION
By moving the uboot environment information to an include file in a known location we can allow other fwup conf files access to the uboot env. This is especially useful when provisioning application dependencies.