### PR TITLE
Enable the Raspberry Pi Touchscreen by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is the base Nerves System configuration for the Raspberry Pi 3 Model B.
 | ADC                  | No                              |
 | PWM                  | Yes, but no Elixir support      |
 | UART                 | 1 available - `ttyAMA0`         |
+| Display              | HDMI or 7" RPi Touchscreen      |
 | Camera               | Yes - via rpi-userland          |
 | Ethernet             | Yes                             |
 | WiFi                 | Yes - Nerves.Network            |

--- a/config.txt
+++ b/config.txt
@@ -24,9 +24,13 @@ dtparam=i2c_arm=on
 dtparam=spi=on
 dtparam=audio=on
 
-# Enable these if you're using the Raspberry Pi 7" Touchscreen
-#dtoverlay=rpi-ft5406
-#dtoverlay=rpi-backlight
+# Enable drivers for the Raspberry Pi 7" Touchscreen
+#
+# This makes it possible to run Scenic out of the box with the popular
+# Raspberry Pi 7" Touchscreen. It appears to be harmless for non-touchscreen
+# users, but if not, let us know!
+dtoverlay=rpi-ft5406
+dtoverlay=rpi-backlight
 
 # Comment this in or modify to enable OneWire
 # NOTE: check that the overlay that you specify is in the boot partition or


### PR DESCRIPTION
This makes it possible to support Scenic using an official Nerves
system on the popular Raspberry Pi 7" Touchscreen.

This appears harmless to non-touchscreen users, but I left a comment in
the config.txt in the hopes that if any negative effects were seen by
the community that we can at least know about them.