### PR TITLE
Fixes typo in config.txt

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -14,7 +14,7 @@ kernel=zImage
 # Disable the boot rainbow
 disable_splash=1
 
-# This, along with the Raspberry Pi "x" firmware is need for the camera
+# This, along with the Raspberry Pi "x" firmware is needed for the camera
 # to work. The Raspberry Pi "x" firmware is selected via the Buildroot
 # configuration. See Target packages->Hardware handling->Firmware.
 gpu_mem=192


### PR DESCRIPTION
Fixing a small typo in config.txt. Same change as proposed in: https://github.com/nerves-project/nerves_system_rpi0/pull/82