### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{in,mk}]
+insert_final_newline = true


### PR DESCRIPTION
So everybody using editorconfigs won't hit buildroot errors because of missing new lines