### PR TITLE
bump fwup version requirement to 1.3.0 for expand functionality

### DIFF
--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -11,7 +11,7 @@
 #
 # It is critical that this is kept in sync with the main fwup.conf.
 
-require-fwup-version="0.19.0"
+require-fwup-version="1.3.0"
 
 #
 # Firmware metadata

--- a/fwup.conf
+++ b/fwup.conf
@@ -1,6 +1,6 @@
 # Firmware configuration file for the Raspberry Pi 3
 
-require-fwup-version="0.15.0"  # For the trim() call
+require-fwup-version="1.3.0"  # For expanding fs
 
 #
 # Firmware metadata


### PR DESCRIPTION
This error has popped up quite a bit lately from some who are using much older versions of `fwup`:

```
... nerves/artifacts/nerves_system_rpi3-portable-1.11.0/images/fwup.conf:162: no such option 'expand'
```

As far as I can tell, the `expand` functionality was added in fwup 1.3, so this changes the requirement  so those people will now get a "fwup needs to be updated" error, instead of something less helpful