### PR TITLE
Remove auto-mount of memory cgroup

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -51,7 +51,6 @@
 -m pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:
 -m tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
 -m cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu
--m memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory
 
 # Erlang release search path
 -r /srv/erlang


### PR DESCRIPTION
The memory cgroup is disabled in the Raspberry Pi Linux kernel by
default now. See https://github.com/raspberrypi/linux/issues/1950 for
discussion.