### PR TITLE
Download/verify source at the beginning of builds

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -123,9 +123,14 @@ defmodule NervesSystemRpi3.MixProject do
   end
 
   defp build_runner_opts() do
+    # Download source files first to get download errors right away.
+    [make_args: primary_site() ++ ["source", "all"]]
+  end
+
+  defp primary_site() do
     case System.get_env("BR2_PRIMARY_SITE") do
       nil -> []
-      primary_site -> [make_args: ["BR2_PRIMARY_SITE=#{primary_site}"]]
+      primary_site -> ["BR2_PRIMARY_SITE=#{primary_site}"]
     end
   end
 


### PR DESCRIPTION
This avoids the 30+ minute CI build failures due to a failed download.
