### PR TITLE
Set the core_freq to fix /dev/ttyS0

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -41,6 +41,8 @@ dtoverlay=rpi-backlight
 # information across reboots in DRAM
 dtoverlay=ramoops
 
-# Enable the UART (/dev/ttyAMA0) on the RPi3.
-enable_uart=1
 dtoverlay=miniuart-bt
+# Set the core frequency so that the built-in UART (/dev/ttyS0) operates at the correct speed.
+# This does slow down processing a bit, so for higher processing applications that don't need
+# this UART you may want to remove this line.
+core_freq=250


### PR DESCRIPTION
I wasn't sure what sort of comment to put for: `dtoverlay=miniuart-bt` so I didn't leave one, but it would be nice to include one if possible.

Here's Frank's summary of this setting:
> I read more up on this and I think I understand why this has been so confusing. The core_freq=250 forces one the clocks on most of the Raspberry Pis, but it makes the mini UART have the right timing. If you don't set it, the RPi will raise or lower the core_freq based on how busy it is. So earlier when you didn't have it set, the RPi was busy at boot and it was presumably running faster so the UART wouldn't work. Then when things calmed down, the RPi would naturally lower the core_freq back to the minimum of 250 and then the UART would transfer data correctly and things would work.